### PR TITLE
Allow functions with dom element parameters

### DIFF
--- a/html/squeak_headless_bundle.js
+++ b/html/squeak_headless_bundle.js
@@ -10746,6 +10746,8 @@
             return this.arrayAsJavascriptObject(obj);
           } else if(obj.sqClass === this.dictionaryClass) {
             return this.dictionaryAsJavascriptObject(obj);
+          } else if(obj.domElement) {
+            return obj.domElement;
           }
           // Assume a String is used otherwise
           return obj.asString();


### PR DESCRIPTION
If you need to call a function and pass a domElement the previous code interprets it as a string (the fallback), however it can also check for the common occurence of a DomElement

(I needed this to get dialogs to work modally as they use a mechanism to stop the current event, and this didn't work with the smalltalk code)